### PR TITLE
Adds handling for case where user supplied other than as POST with user.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Deploy the application on Azure Functions with the Azure Function Maven plug-in:
 
 You can then test the running application:
 
-`curl https://<YOUR_SPRING_FUNCTION_NAME>.azurewebsites.net/api/hello -d "{\"name\":\"Azure\"}"`
+```
+curl https://<YOUR_SPRING_FUNCTION_NAME>.azurewebsites.net/api/hello -d "{\"name\":\"Azure\"}"
+curl https://<YOUR_SPRING_FUNCTION_NAME>.azurewebsites.net/api/hello?name=Azure
+```
 
 Replace the `<YOUR_SPRING_FUNCTION_NAME>` part by the name of your Spring Function.

--- a/src/main/java/com/example/HelloHandler.java
+++ b/src/main/java/com/example/HelloHandler.java
@@ -16,11 +16,16 @@ public class HelloHandler extends AzureSpringBootRequestHandler<User, Greeting> 
     public HttpResponseMessage execute(
             @HttpTrigger(name = "request", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<User>> request,
             ExecutionContext context) {
-
-        context.getLogger().info("Greeting user name: " + request.getBody().get().getName());
+        User user = request.getBody()
+                .filter((u -> u.getName() != null))
+                .orElseGet(() -> new User(
+                        request.getQueryParameters()
+                                .getOrDefault("name", "<no name supplied> please provide a name as " +
+                                        "either a querystring parameter or in a POST body")));
+        context.getLogger().info("Greeting user name: " + user.getName());
         return request
                 .createResponseBuilder(HttpStatus.OK)
-                .body(handleRequest(request.getBody().get(), context))
+                .body(handleRequest(user, context))
                 .header("Content-Type", "application/json")
                 .build();
     }


### PR DESCRIPTION
## Purpose
Adds handling for case where user supplied other than as POST with user.name

`Optional<User>` may be null, or the triggering request may be a GET instead of a POST, both of which lead to a null pointer. This adds handling to account for:
* GET ?name=###: results in returned User with supplied name
* GET or POST with no name supplied: results in returned User with name = _\<no name supplied\> please provide a name as either a querystring parameter or in a POST body_

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
